### PR TITLE
新増 C# SDK (反向WebSocket)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | ⭐ | Go | 标准库 | **API:**<br>HTTP,<br>WebSocket<br>**Event:**<br>HTTP,<br>长轮询,<br>WebSocket,<br>反向 WebSocket | [catsworld/qq-bot-api](https://github.com/catsworld/qq-bot-api) | catsworld<br>rikakomoe |
 | ⭐ | C# | 标准库 | HTTP,<br>WebSocket | [int-and-his-friends/Sisters.WudiLib](https://github.com/int-and-his-friends/Sisters.WudiLib) | bleatingsheep |
 | ⭐ | C# | 标准库 | HTTP,<br>WebSocket,<br>反向 WebSocket | [frank-bots/cqhttp.Cyan](https://github.com/frank-bots/cqhttp.Cyan) | frankli0324 |
+|  | NETCore | 标准库 | 反向 WebSocket | [cqbef/cqhttp.WebSocketReverse.NETCore](https://github.com/cqbef/cqhttp.WebSocketReverse.NETCore) | cqbef |
 |  | PowerShell | - | HTTP | [cqmoe/cqhttp-powershell-sdk](https://github.com/cqmoe/cqhttp-powershell-sdk) | richardchien |
 
 ## 应用案例

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | ⭐ | Go | 标准库 | **API:**<br>HTTP,<br>WebSocket<br>**Event:**<br>HTTP,<br>长轮询,<br>WebSocket,<br>反向 WebSocket | [catsworld/qq-bot-api](https://github.com/catsworld/qq-bot-api) | catsworld<br>rikakomoe |
 | ⭐ | C# | 标准库 | HTTP,<br>WebSocket | [int-and-his-friends/Sisters.WudiLib](https://github.com/int-and-his-friends/Sisters.WudiLib) | bleatingsheep |
 | ⭐ | C# | 标准库 | HTTP,<br>WebSocket,<br>反向 WebSocket | [frank-bots/cqhttp.Cyan](https://github.com/frank-bots/cqhttp.Cyan) | frankli0324 |
-|  | NETCore | 标准库 | 反向 WebSocket | [cqbef/cqhttp.WebSocketReverse.NETCore](https://github.com/cqbef/cqhttp.WebSocketReverse.NETCore) | cqbef |
+|  | C# NETCore3.1 | Fleck | 反向 WebSocket | [cqbef/cqhttp.WebSocketReverse.NETCore](https://github.com/cqbef/cqhttp.WebSocketReverse.NETCore) | cqbef |
 |  | PowerShell | - | HTTP | [cqmoe/cqhttp-powershell-sdk](https://github.com/cqmoe/cqhttp-powershell-sdk) | richardchien |
 
 ## 应用案例


### PR DESCRIPTION
[cqhttp.WebSocketReverse.NETCore](https://github.com/cqbef/cqhttp.WebSocketReverse.NETCore)

该SDK提供WebSocket服务端供CQHTTP插件的反向WebSocket通道连接


#### 应用范例

```cs

WebSocketServer wss = new WebSocketServer ("ws://0.0.0.0:8889");
CqHttpParse parse = new CqHttpParse(CqHttpApi.SetResult);
CqHttpApi.Timeout = TimeSpan.FromSeconds(10);

wss.OnAuthorization += async (s, e) =>
{
   await Task.Run(() =>
   {
      Debug.WriteLine(e.Connection.WebSocketConnectionInfo.ClientIpAddress);
      e.Allow();
   });
};
wss.OnReceiveMessage += async (s, e) =>
{
   await parse.Parse(s, e);
};
parse.OnPrivateMessage += async (n, b) =>
{
   var vipinfo = await b.Source.GetVipInfo();
   if(vipinfo.VipLevel == "普通用户")
   {
      await b.Source.Replay(b.Message);
   }else
   {
      long qqId = 123456789;
      int messageId = await b.Source.SendPrivateMessage(qqId,$"{b.Sender.NickName}对你说:{b.Message}");
      if(messageId>0)await b.Source.Replay("已传达消息到主人");
   }
};

```
