### PR TITLE
给文档初步添加离线浏览功能

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
   <script src="https://unpkg.com/docute@3/dist/docute.js"></script>
   <script src="https://unpkg.com/prismjs/components/prism-bash.min.js"></script>
   <script>
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js')
+    }
     docute.init({
       title: 'CoolQ HTTP API 插件',
       repo: 'richardchien/coolq-http-api',

--- a/sw.js
+++ b/sw.js
@@ -2,14 +2,6 @@ importScripts(
   'https://storage.googleapis.com/workbox-cdn/releases/3.6.1/workbox-sw.js'
 )
 
-const ALLOWED_HOSTS = [
-  'cqhttp.cc',
-  'cqhttp.bleatingsheep.org',
-  'img.shields.io',
-  'raw.githubusercontent.com',
-  'unpkg.com'
-]
-
 const matchCb = ({ url, event }) => {
   return true
 }

--- a/sw.js
+++ b/sw.js
@@ -5,6 +5,8 @@ importScripts(
 const ALLOWED_HOSTS = [
   'cqhttp.cc',
   'cqhttp.bleatingsheep.org',
+  'img.shields.io',
+  'raw.githubusercontent.com',
   'unpkg.com'
 ]
 

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,17 @@
+importScripts(
+  'https://storage.googleapis.com/workbox-cdn/releases/3.6.1/workbox-sw.js'
+)
+
+const ALLOWED_HOSTS = [
+  'cqhttp.cc',
+  'cqhttp.bleatingsheep.org'
+]
+
+const matchCb = ({ url, event }) => {
+  return event.request.method === 'GET' && ALLOWED_HOSTS.includes(url.host)
+}
+
+workbox.routing.registerRoute(
+  matchCb,
+  workbox.strategies.networkFirst()
+)

--- a/sw.js
+++ b/sw.js
@@ -11,7 +11,7 @@ const ALLOWED_HOSTS = [
 ]
 
 const matchCb = ({ url, event }) => {
-  return event.request.method === 'GET' && ALLOWED_HOSTS.includes(url.host)
+  return true
 }
 
 workbox.routing.registerRoute(

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,8 @@ importScripts(
 
 const ALLOWED_HOSTS = [
   'cqhttp.cc',
-  'cqhttp.bleatingsheep.org'
+  'cqhttp.bleatingsheep.org',
+  'unpkg.com'
 ]
 
 const matchCb = ({ url, event }) => {


### PR DESCRIPTION
参考：https://docute.org/guide/offline-support

目前的局限：

- 必须先访问一次首页才能启用
- 只能离线查看看过的页面

效果见：https://cqhttp.bleatingsheep.org/

先访问首页，再随便访问几个页面，然后在F12里勾上禁用缓存，网络设为脱机，再打开刚才访问过的页面，刷新刷新看看效果。

**commit 较乱，建议merge为一个commit**

你要是有兴趣，可以做成PWA（