### PR TITLE
Added: 添加应用案例 Wecab

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ QQ 机器人可以用来做很多有意思的事情，下面列出一些基于�
 | [cleoold/sendo-erika](https://github.com/cleoold/sendo-erika) | 基于 cqhttp 和 NoneBot 的，主要通过私聊摇控的 QQ 机器人 |
 | [duan602728596/qqtools](https://github.com/duan602728596/qqtools) | 基于 Nwjs 的 QQ 群工具（摩点、口袋 48、微博提醒、入群欢迎、定时喊话、自定义命令和回复信息等） |
 | [Tsuk1ko/CQ-picfinder-robot](https://github.com/Tsuk1ko/CQ-picfinder-robot) | 基于 Saucenao 的搜图机器人 |
+| [Ninzore/Wecab](https://github.com/Ninzore/Wecab) | 最好的订阅制综合型bot，支持微博，B站，Twitter，还有更多！ |
 | [kasora/dice](https://github.com/kasora/dice) | COC7 骰子 QQ 机器人 |
 | [shidenggui/tuishujun-for-qq](https://github.com/shidenggui/tuishujun-for-qq) | 基于推书君的小说查询推荐 QQ 机器人 |
 | [JuerGenie/cn.juerwhang.jgbot](https://github.com/JuerGenie/cn.juerwhang.jgbot) | 基于 [JuerGenie/juerobot](https://github.com/JuerGenie/juerobot) 的娱乐用 QQ 机器人 |


### PR DESCRIPTION
前身是[CQ-picfinder-robot](https://github.com/Tsuk1ko/CQ-picfinder-robot)的插件，经过多次魔改已经完全脱离原项目  
现在能查看，翻阅，订阅微博，B站动态，Twitter，还有其他各种小功能